### PR TITLE
Efs csi driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# Dockerfile for custom jupyterlab user environment
+FROM jupyter/datascience-notebook:6aded4bc1d84
+
+# Install jupyter extensions
+RUN pip install -U jupyterlab-git jupyter-scheduler ipython-sql voila

--- a/cdk.py
+++ b/cdk.py
@@ -1,43 +1,37 @@
+from typing import Self
+
 import aws_cdk as cdk
 import aws_cdk.aws_ec2 as ec2
+import aws_cdk.aws_ecr_assets as ecr_assets
 import aws_cdk.aws_eks as eks
 import aws_cdk.aws_iam as iam
 import yaml
-from constructs import Construct
-from typing import Self
 from aws_cdk.lambda_layer_kubectl import KubectlLayer
+from constructs import Construct
 
+# These constants are set for a transient "dev" deployment
 REMOVAL_POLICY = cdk.RemovalPolicy.DESTROY
 DELETION_PROTECTION = False
 
 
-class JupyterHubStack(cdk.Stack):
+class JupyterhubStack(cdk.Stack):
     def __init__(
         self, scope: Construct, id: str, vpc_id: str | None = None, masters_role_arn: str | None = None, **kwargs
     ) -> Self:
         super().__init__(scope, id, **kwargs)
 
-        if masters_role_arn is None:
-            masters_role = iam.Role(
-                self,
-                "MastersRole",
-                assumed_by=iam.AccountPrincipal(self.account),
-            )
-        else:
-            masters_role = iam.Role.from_role_arn(self, "MastersRole", masters_role_arn)
+        masters_role = iam.Role(
+            self,
+            "MastersRole",
+            assumed_by=iam.AccountPrincipal(self.account),
+        )
 
-        if vpc_id is None:
-            vpc = ec2.Vpc(self, "Vpc")
-        else:
-            vpc = ec2.Vpc.from_lookup(vpc_id=vpc_id)
-
-        # provisioning a cluster
+        # Provision a Kubernetes cluster
         cluster = eks.Cluster(
             self,
             "K8sCluster",
             version=eks.KubernetesVersion.V1_27,
             kubectl_layer=KubectlLayer(self, "kubectl-layer"),
-            vpc=vpc,
             masters_role=masters_role,
             output_masters_role_arn=True,
             output_cluster_name=True,
@@ -51,6 +45,14 @@ class JupyterHubStack(cdk.Stack):
                 eks.ClusterLoggingTypes.AUTHENTICATOR,
                 eks.ClusterLoggingTypes.CONTROLLER_MANAGER,
             ],
+        )
+
+        # Grant masters role necessary permissions
+        masters_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["eks:AccessKubernetesApi", "eks:Describe*", "eks:List*"],
+                resources=[cluster.cluster_arn],
+            )
         )
 
         # Add EBS CSI driver addon
@@ -82,30 +84,55 @@ class JupyterHubStack(cdk.Stack):
             cluster_name=cluster.cluster_name,
             service_account_role_arn=ebs_csi_addon_role.role_arn,
         )
+        ebs_csi_addon.apply_removal_policy(REMOVAL_POLICY)
 
-        # Grant masters role necessary permissions
-        masters_role.add_to_policy(
-            iam.PolicyStatement(
-                actions=["eks:AccessKubernetesApi", "eks:Describe*", "eks:List*"],
-                resources=[cluster.cluster_arn],
-            )
+        # Build and deploy custom docker image
+        image = ecr_assets.DockerImageAsset(
+            self,
+            "UserServerBaseImage",
+            directory=".",
+            platform=ecr_assets.Platform.LINUX_AMD64,
+        )
+        cdk.CfnOutput(
+            self,
+            "ImageUri",
+            value=image.image_uri,
+            description="URI of image deployed to ECR repository.",
         )
 
-        # Deploy Jupyterhub helm chart
+        # Parse config for Jupyterhub helm chart
         with open("config.yaml", "r") as f:
-            eks.HelmChart(
-                self,
-                "JupyterHubHelmChart",
-                cluster=cluster,
-                chart="jupyterhub",
-                repository="https://jupyterhub.github.io/helm-chart/",
-                namespace="jupyterhub",
-                create_namespace=True,
-                release="jupyterhub",
-                version="3.0.1",
-                wait=True,
-                values=yaml.load(f, Loader=yaml.Loader),
-            )
+            config = yaml.load(f, Loader=yaml.Loader)
+
+        # Add our custom image to the helm chart config
+        config["singleuser"]["image"] = {
+            "name": image.repository.repository_uri,
+            "tag": image.image_tag,
+        }
+
+        # Create a K8s secret to grant permissions to pull from private ECR registry
+        config["imagePullSecret"] = {
+            "create": True,
+            "registry": image.repository.repository_uri,
+            "username": "aws",
+            "email": "__token__",
+            "password": "aws ecr get-login-password --region us-east-1 | cut -d' ' -f6",
+        }
+
+        # Deploy Jupyterhub helm chart
+        eks.HelmChart(
+            self,
+            "JupyterHubHelmChart",
+            cluster=cluster,
+            chart="jupyterhub",
+            repository="https://jupyterhub.github.io/helm-chart/",
+            namespace="jupyterhub",
+            create_namespace=True,
+            release="jupyterhub",
+            version="3.0.2",
+            wait=True,
+            values=config,
+        )
 
         # Expose service endpoint as stack output
         jupyterhub_endpoint = cluster.get_service_load_balancer_address("proxy-public", namespace="jupyterhub")
@@ -120,7 +147,7 @@ class JupyterHubStack(cdk.Stack):
 if __name__ == "__main__":
     app = cdk.App()
 
-    JupyterHubStack(
+    JupyterhubStack(
         app,
         "EksJupyterhub",
         termination_protection=DELETION_PROTECTION,

--- a/cdk.py
+++ b/cdk.py
@@ -3,6 +3,7 @@ from typing import Self
 import aws_cdk as cdk
 import aws_cdk.aws_ec2 as ec2
 import aws_cdk.aws_ecr_assets as ecr_assets
+import aws_cdk.aws_efs as efs
 import aws_cdk.aws_eks as eks
 import aws_cdk.aws_iam as iam
 import yaml
@@ -12,6 +13,7 @@ from constructs import Construct
 # These constants are set for a transient "dev" deployment
 REMOVAL_POLICY = cdk.RemovalPolicy.DESTROY
 DELETION_PROTECTION = False
+AUTOMATIC_BACKUPS = False
 
 
 class JupyterhubStack(cdk.Stack):
@@ -45,6 +47,7 @@ class JupyterhubStack(cdk.Stack):
                 eks.ClusterLoggingTypes.AUTHENTICATOR,
                 eks.ClusterLoggingTypes.CONTROLLER_MANAGER,
             ],
+            service_ipv4_cidr="172.20.0.0/16",
         )
 
         # Grant masters role necessary permissions
@@ -55,36 +58,88 @@ class JupyterhubStack(cdk.Stack):
             )
         )
 
-        # Add EBS CSI driver addon
+        # Add EFS CSI driver addon
         oid_connect_issuer_id = cluster.open_id_connect_provider.open_id_connect_provider_issuer.replace("https://", "")
-        ebs_csi_addon_role_policy_condition = cdk.CfnJson(
+        efs_csi_addon_role_policy_condition = cdk.CfnJson(
             self,
-            "K8sEbsAddonPolicyCondition",
+            "K8sEfsAddonPolicyCondition",
             value={
                 f"{oid_connect_issuer_id}:aud": "sts.amazonaws.com",
-                f"{oid_connect_issuer_id}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa",
+                f"{oid_connect_issuer_id}:sub": "system:serviceaccount:kube-system:efs-csi-*",
             },
         )
-        ebs_csi_addon_role = iam.Role(
+        efs_csi_addon_role = iam.Role(
             self,
-            "K8sEbsAddonRole",
+            "K8sEfsAddonRole",
             assumed_by=iam.FederatedPrincipal(
                 federated=cluster.open_id_connect_provider.open_id_connect_provider_arn,
-                conditions={"StringEquals": ebs_csi_addon_role_policy_condition},
+                conditions={"StringLike": efs_csi_addon_role_policy_condition},
                 assume_role_action="sts:AssumeRoleWithWebIdentity",
             ),
         )
-        ebs_csi_addon_role.add_managed_policy(
-            iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AmazonEBSCSIDriverPolicy")
+        efs_csi_addon_role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AmazonEFSCSIDriverPolicy")
         )
-        ebs_csi_addon = eks.CfnAddon(
+        efs_csi_addon = eks.CfnAddon(
             self,
-            "K8sEbsCsiAddon",
-            addon_name="aws-ebs-csi-driver",
+            "K8sEfsCsiAddon",
+            addon_name="aws-efs-csi-driver",
             cluster_name=cluster.cluster_name,
-            service_account_role_arn=ebs_csi_addon_role.role_arn,
+            service_account_role_arn=efs_csi_addon_role.role_arn,
         )
-        ebs_csi_addon.apply_removal_policy(REMOVAL_POLICY)
+        efs_csi_addon.apply_removal_policy(REMOVAL_POLICY)
+
+        efs_security_group = ec2.SecurityGroup(
+            self,
+            "EfsSecurityGroup",
+            vpc=cluster.vpc,
+            allow_all_outbound=True,
+        )
+        efs_security_group.add_ingress_rule(
+            ec2.Peer.ipv4(cluster.vpc.vpc_cidr_block),
+            ec2.Port.tcp(2049),
+            description="Allow all inbound NFS traffic from VPC.",
+        )
+        efs_security_group.add_ingress_rule(
+            ec2.Peer.ipv4("172.20.0.0/16"),
+            ec2.Port.tcp(2049),
+            description="Allow all inbound NFS traffic from EKS cluster.",
+        )
+        file_system = efs.FileSystem(
+            self,
+            "FileSystem",
+            vpc=cluster.vpc,
+            lifecycle_policy=efs.LifecyclePolicy.AFTER_14_DAYS,
+            out_of_infrequent_access_policy=efs.OutOfInfrequentAccessPolicy.AFTER_1_ACCESS,
+            removal_policy=REMOVAL_POLICY,
+            security_group=efs_security_group,
+            enable_automatic_backups=AUTOMATIC_BACKUPS,
+        )
+
+        eks_namespace = cluster.add_manifest(
+            "EksNamespace",
+            {
+                "apiVersion": "v1",
+                "kind": "Namespace",
+                "metadata": {"name": "jupyterhub"},
+            },
+        )
+
+        efs_storage_class = cluster.add_manifest(
+            "EfsStorageClass",
+            {
+                "apiVersion": "storage.k8s.io/v1",
+                "kind": "StorageClass",
+                "metadata": {"name": "efs", "namespace": "jupyterhub"},
+                "provisioner": "efs.csi.aws.com",
+                "parameters": {
+                    "provisioningMode": "efs-ap",
+                    "fileSystemId": file_system.file_system_id,
+                    "directoryPerms": "700",
+                },
+            },
+        )
+        efs_storage_class.node.add_dependency(eks_namespace)
 
         # Build and deploy custom docker image
         image = ecr_assets.DockerImageAsset(
@@ -119,8 +174,8 @@ class JupyterhubStack(cdk.Stack):
             "password": "aws ecr get-login-password --region us-east-1 | cut -d' ' -f6",
         }
 
-        # Deploy Jupyterhub helm chart
-        eks.HelmChart(
+        # # Deploy Jupyterhub helm chart
+        jupyterhub = eks.HelmChart(
             self,
             "JupyterHubHelmChart",
             cluster=cluster,
@@ -129,10 +184,11 @@ class JupyterhubStack(cdk.Stack):
             namespace="jupyterhub",
             create_namespace=True,
             release="jupyterhub",
-            version="3.0.2",
+            version="3.0.3",
             wait=True,
             values=config,
         )
+        jupyterhub.node.add_dependency(efs_storage_class)
 
         # Expose service endpoint as stack output
         jupyterhub_endpoint = cluster.get_service_load_balancer_address("proxy-public", namespace="jupyterhub")

--- a/config.yaml
+++ b/config.yaml
@@ -1,1 +1,28 @@
-# jupyterhub helm chart config
+# Jupyterhub helm chart config
+
+singleuser:
+  # Set defaults for resource guarantees and limits
+  storage:
+    capacity: 2Gi
+  
+  # Create different "profiles" which users can sign in to
+  profileList:
+    - display_name: "X Small"
+      description: "512MB memory, 0.5 CPU"
+      memory:
+        limit: "512M"
+        guarantee: "512M"
+      cpu:
+        limit: .5
+        guarantee: .5
+      default: true
+    - display_name: "Small"
+      description: "1GB memory, 1 CPU"
+      # Larger resource guarantees and limits for compute heavy workloads
+      kubespawner_override:
+        cpu:
+          guarantee: 1
+          limit: 1
+        memory:
+          guranatee: 1G
+          limit: 1G

--- a/config.yaml
+++ b/config.yaml
@@ -4,16 +4,15 @@ singleuser:
   storage:
     dynamic:
       storageClass: "efs"
+  memory:
+    limit: "512M"
+    guarantee: "512M"
+  cpu:
+    limit: .5
+    guarantee: .5
   profileList:
-    - display_name: "X Small"
+    - display_name: "Extra Small"
       description: "512MB memory, 0.5 CPU"
-      kubespawner_override:
-        memory:
-          limit: "512M"
-          guarantee: "512M"
-        cpu:
-          limit: .5
-          guarantee: .5
       default: true
     - display_name: "Small"
       description: "1GB memory, 1 CPU"

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,8 @@ singleuser:
     limit: .5
     guarantee: .5
   storage:
-    capacity: 2Gi
+    dynamic:
+      storageClass: "efs"
   
   # Create different "profiles" which users can sign in to
   profileList:
@@ -26,3 +27,8 @@ singleuser:
         memory:
           guranatee: 2G
           limit: 2G
+
+hub:
+  db:
+    pvc:
+      storageClassName: "efs"


### PR DESCRIPTION
# What

Switches persistence layer from EBS to EFS.

# Why

EBS volumes doesn't support a `ReadWriteMany` claim, which is needed for a "shared" directory on jupyterhub.

Beyond this, EFS seems simpler to manage from a backup and administration perspective.

# Resources

https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html
