### PR TITLE
Give users a shared directory to publish files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eks_jupyterhub
 
-An example JupyterHub deployment on EKS.
+An example Jupyterhub deployment on EKS.
 
 For full details on configuration options and security best practices, please refer to the [Jupyterhub on Kubernetes 
 documentation](https://z2jh.jupyter.org/en/stable/index.html).

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,13 @@ singleuser:
   storage:
     dynamic:
       storageClass: "efs"
+    extraVolumes:
+      - name: jupyterhub-shared
+        persistentVolumeClaim:
+          claimName: jupyterhub-shared-claim
+    extraVolumeMounts:
+      - name: jupyterhub-shared
+        mountPath: /home/jovyan/shared
   memory:
     limit: "512M"
     guarantee: "512M"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [project]
 name = "eks_jupyterhub"
 version = "0.0.0"
-description = "An AWS CDK app for JupyterHub on EKS."
+description = "An AWS CDK app for Jupyterhub on EKS."
 authors = [
     {name = "Grayden Shand", email = "gshand@beta.team"},
 ]


### PR DESCRIPTION
# What

Creates a public "shared" directory that all users have access to.

# Why

Having a shared directory is crucial to collaborating with others. For example one may want to publish a Voila dashboard, or ask a colleague to review a notebook. 

# How

We set up a new `PersistentVolume` with `ReadWriteMany` access mode using our EFS StorageClass. We then mount that volume to each singleuser container at `/home/jovyan/shared`. The result is a directory named "shared" appears at the root of a user's file system, containing all of the files in the shared volume.

<img width="772" alt="Screenshot 2023-09-05 at 8 06 33 AM" src="https://github.com/graydenshand/eks_jupyterhub/assets/38144548/20aa432b-68e4-4959-9f5b-8b592bce9c3f">
